### PR TITLE
Format payload as valid json

### DIFF
--- a/rewrite/lomiri.go
+++ b/rewrite/lomiri.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+        "encoding/json"
 
 	"github.com/karmanyaahm/up_rewrite/utils"
 )
@@ -35,11 +36,13 @@ func (l Lomiri) Req(body []byte, req http.Request) (*http.Request, error) {
 	token := req.URL.Query().Get("token")
 	appid := req.URL.Query().Get("appid")
 
+	var payload map[string]interface{}
+        err := json.Unmarshal(body, &payload)
 	newBody, err := utils.EncodeJSON(lomiriSend{
 		Token:    token,
 		AppId:    appid,
 		ExpireOn: time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339),
-		Data:     string(body),
+		Data:     paylod,
 	})
 
 	if err != nil {

--- a/rewrite/lomiri.go
+++ b/rewrite/lomiri.go
@@ -42,7 +42,7 @@ func (l Lomiri) Req(body []byte, req http.Request) (*http.Request, error) {
 		Token:    token,
 		AppId:    appid,
 		ExpireOn: time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339),
-		Data:     paylod,
+		Data:     payload,
 	})
 
 	if err != nil {


### PR DESCRIPTION
The data element should hold a json structure for now. A string would be escaped and be rejected by the client on the device.